### PR TITLE
fix: disable for usb image

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,2 +1,3 @@
 - name: restart sshd
   service: name={{ sshd_service_name }} state=restarted
+  tags: usb


### PR DESCRIPTION
Allow to run on a USB where you can not trigger service restarts during creation